### PR TITLE
Close crop activity

### DIFF
--- a/cropper/src/main/java/com/canhub/cropper/CropImageActivity.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageActivity.kt
@@ -44,7 +44,7 @@ open class CropImageActivity :
             onPickImageResult(uri)
         }
     private val takePicture = registerForActivityResult(ActivityResultContracts.TakePicture()) {
-        if (it) onPickImageResult(latestTmpUri)
+        if (it) onPickImageResult(latestTmpUri) else onPickImageResult(null)
     }
 
     public override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
how to reproduce/test 

click TAKE CAMERA PIC ... WITH URI, when camera opens , click back button .  
It still shows the crop activity , without any image, but  should close the activity  when TakeCamera() contract result is null or false. 
